### PR TITLE
Publish version 0.1.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^\.positai$
+^\.claude$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^pkgdown$
 ^\.positai$
 ^\.claude$
+^CITATION\.cff$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 .quarto
 docs
+.positai

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,188 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
+message: 'To cite package "reasin" in publications use:'
+type: software
+license: MIT
+title: 'reasin: Interface to the European Alien Species Information Network API'
+version: 0.0.1.0
+abstract: A programmatic interface to the Web Service methods provided by European
+  Alien Species Information Network (EASIN). At the moment only interface to the EASIN
+  Catalogue Web Service (checklist data) is implemented.
 authors:
-- family-names: "Oldoni"
-  given-names: "Damiano"
-  orcid: "0000-0003-3445-7562"
-title: "reasin"
-version: 0.0.0.9000
-url: "https://github.com/guardias-eu/reasin"
+- family-names: Oldoni
+  given-names: Damiano
+  email: damiano.oldoni@inbo.be
+  orcid: https://orcid.org/0000-0003-3445-7562
+  affiliation: Research Institute for Nature and Forest (INBO)
+repository-code: https://github.com/guardias-eu/reasin
+url: https://guardias-eu.github.io/reasin/
+date-released: '2026-05-28'
+contact:
+- family-names: Oldoni
+  given-names: Damiano
+  email: damiano.oldoni@inbo.be
+  orcid: https://orcid.org/0000-0003-3445-7562
+  affiliation: Research Institute for Nature and Forest (INBO)
+keywords:
+- api
+- biodiversity
+- biodiversity-data
+- biodiversity-informatics
+- data
+- invasive-species
+- oscibio
+- r
+- r-package
+references:
+- type: software
+  title: cli
+  abstract: 'cli: Helpers for Developing Command Line Interfaces'
+  notes: Imports
+  url: https://cli.r-lib.org
+  repository: https://CRAN.R-project.org/package=cli
+  authors:
+  - family-names: Csárdi
+    given-names: Gábor
+    email: gabor@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.cli
+- type: software
+  title: dplyr
+  abstract: 'dplyr: A Grammar of Data Manipulation'
+  notes: Imports
+  url: https://dplyr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=dplyr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: François
+    given-names: Romain
+    orcid: https://orcid.org/0000-0002-2444-4226
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Müller
+    given-names: Kirill
+    orcid: https://orcid.org/0000-0002-1416-3412
+  - family-names: Vaughan
+    given-names: Davis
+    email: davis@posit.co
+    orcid: https://orcid.org/0000-0003-4777-038X
+  year: '2026'
+  doi: 10.32614/CRAN.package.dplyr
+- type: software
+  title: glue
+  abstract: 'glue: Interpreted String Literals'
+  notes: Imports
+  url: https://glue.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=glue
+  authors:
+  - family-names: Hester
+    given-names: Jim
+    orcid: https://orcid.org/0000-0002-2739-7082
+  - family-names: Bryan
+    given-names: Jennifer
+    email: jenny@posit.co
+    orcid: https://orcid.org/0000-0002-6983-2759
+  year: '2026'
+  doi: 10.32614/CRAN.package.glue
+- type: software
+  title: httr2
+  abstract: 'httr2: Perform HTTP Requests and Process the Responses'
+  notes: Imports
+  url: https://httr2.r-lib.org
+  repository: https://CRAN.R-project.org/package=httr2
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.httr2
+- type: software
+  title: jsonlite
+  abstract: 'jsonlite: A Simple and Robust JSON Parser and Generator for R'
+  notes: Imports
+  url: https://jeroen.r-universe.dev/jsonlite
+  repository: https://CRAN.R-project.org/package=jsonlite
+  authors:
+  - family-names: Ooms
+    given-names: Jeroen
+    email: jeroenooms@gmail.com
+    orcid: https://orcid.org/0000-0002-4035-0289
+  year: '2026'
+  doi: 10.32614/CRAN.package.jsonlite
+- type: software
+  title: magrittr
+  abstract: 'magrittr: A Forward-Pipe Operator for R'
+  notes: Imports
+  url: https://magrittr.tidyverse.org
+  repository: https://CRAN.R-project.org/package=magrittr
+  authors:
+  - family-names: Bache
+    given-names: Stefan Milton
+    email: stefan@stefanbache.dk
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.magrittr
+- type: software
+  title: purrr
+  abstract: 'purrr: Functional Programming Tools'
+  notes: Imports
+  url: https://purrr.tidyverse.org/
+  repository: https://CRAN.R-project.org/package=purrr
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.purrr
+- type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Suggests
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.testthat
+- type: software
+  title: vcr
+  abstract: 'vcr: Record ''HTTP'' Calls to Disk'
+  notes: Suggests
+  url: https://github.com/ropensci/vcr/
+  repository: https://CRAN.R-project.org/package=vcr
+  authors:
+  - family-names: Chamberlain
+    given-names: Scott
+    email: myrmecocystus@gmail.com
+    orcid: https://orcid.org/0000-0003-1444-9135
+  - family-names: Wolen
+    given-names: Aaron
+    orcid: https://orcid.org/0000-0003-2542-2202
+  - family-names: Salmon
+    given-names: Maëlle
+    orcid: https://orcid.org/0000-0002-2815-0399
+  - family-names: Possenriede
+    given-names: Daniel
+    orcid: https://orcid.org/0000-0002-6738-9845
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.vcr
+  version: '>= 0.6.0'
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Description: A programmatic interface to the Web Service methods provided
     only interface to the EASIN Catalogue Web Service (checklist data) is
     implemented.
 License: MIT + file LICENSE
-URL: https://github.com/guardias-eu/reasin, https://guardias-eu.github.io/reasin/
+URL: https://github.com/guardias-eu/reasin,
+    https://guardias-eu.github.io/reasin/
 BugReports: https://github.com/guardias-eu/reasin/issues
 Imports:
     cli,
@@ -25,9 +26,9 @@ Imports:
     jsonlite,
     magrittr,
     purrr
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 Suggests:
     testthat,
     vcr (>= 0.6.0)
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: reasin
 Title: Interface to the European Alien Species Information Network API
 Version: 0.0.1.0
+Date: 2026-05-28
 Authors@R: c(
     person("Damiano", "Oldoni", , "damiano.oldoni@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3445-7562", affiliation = "Research Institute for Nature and Forest (INBO)")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reasin
 Title: Interface to the European Alien Species Information Network API
-Version: 0.0.0.9000
+Version: 0.0.1.0
 Authors@R: c(
     person("Damiano", "Oldoni", , "damiano.oldoni@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3445-7562", affiliation = "Research Institute for Nature and Forest (INBO)")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,10 @@ Authors@R: c(
     person("GuardIAS", role = "fnd",
            comment = "https://guardias.eu/")
   )
-Description: What the package does (one paragraph).
+Description: A programmatic interface to the Web Service methods provided
+    by European Alien Species Information Network (EASIN). At the moment
+    only interface to the EASIN Catalogue Web Service (checklist data) is
+    implemented.
 License: MIT + file LICENSE
 URL: https://github.com/guardias-eu/reasin, https://guardias-eu.github.io/reasin/
 BugReports: https://github.com/guardias-eu/reasin/issues


### PR DESCRIPTION
This pull request prepares the `reasin` R package for its initial public release, updating its metadata and citation information to reflect its current functionality and dependencies. The changes focus on updating the package version, description, and adding a comprehensive `CITATION.cff` file.
Also, updated `.Rbuildignore` to exclude new files and directories related to documentation and citation (`.positai`, `.claude`, `CITATION.cff`).
Minor reordering and formatting improvements in the `DESCRIPTION` file for consistency, by using `desc_normalize()`.